### PR TITLE
Add Power curves

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests>=2.28.1
-pytest==6.2.2
+pytest==6.2.5
 sphinx-autoapi==1.7.0
 sphinx-rtd-theme==0.5.1

--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,5 @@ setuptools.setup(
     package_dir={'': 'src'},
     py_modules=[splitext(basename(path))[0] for path in glob('src/*.py')],
     python_requires=">=3.6",
-    install_requires=["requests>=2.28.1", "pytest==6.2.2"]
+    install_requires=["requests>=2.28.1", "pytest==6.2.5"]
 )

--- a/src/intervalsicu/__init__.py
+++ b/src/intervalsicu/__init__.py
@@ -4,3 +4,4 @@ from .api.event import Event
 from .api.intervals import Intervals
 from .api.wellness import Wellness
 from .api.workout import Folder, Workout
+from .api.power_curve import PowerCurve

--- a/src/intervalsicu/api/intervals.py
+++ b/src/intervalsicu/api/intervals.py
@@ -8,6 +8,7 @@ from .activity import Activity
 from .event import Event
 from .wellness import Wellness
 from .calendar import Calendar
+from .power_curve import PowerCurve
 
 
 class Intervals(object):
@@ -281,3 +282,40 @@ class Intervals(object):
 
         res = self._make_request("get", url)
         return Workout(**res.json())
+
+    def power_curve(
+        self,
+        newest=datetime.datetime.now(),
+        curves="90d",
+        type="Ride",
+        include_ranks=False,
+        sub_max_efforts=0,
+        filters='[{"field_id": "type", "value": ["Ride", "VirtualRide"]}]',
+    ):
+        """
+        Returns a :class:`PowerCurve` by ID
+
+        :param newest: Datetime of newest possible activity to be included
+        :type newest: datetime.datetime
+        :param curves: Curves to be returned
+        :type curves: str
+        :param type: Activity Type
+        :type type: str
+        :param include_ranks: Include ranks boolean
+        :type include_ranks: bool
+        :param sub_max_efforts: Number of sub max efforts
+        :type sub_max_efforts: int
+        :return: PowerCurve Object
+        :rtype: :class:`PowerCurve`
+        """
+        url = f"{self.URL}/api/v1/athlete/{self.athlete_id}/power-curves"
+        params = {
+            "curves": curves,
+            "type": type,
+            "includeRanks": include_ranks,
+            "subMaxEfforts": f"{sub_max_efforts}",
+            "filters": filters,
+            "newest": newest.strftime("%Y-%m-%dT%H:%M:%S"),
+        }
+        res = self._make_request("get", url, params=params)
+        return PowerCurve(**res.json())

--- a/src/intervalsicu/api/power_curve.py
+++ b/src/intervalsicu/api/power_curve.py
@@ -1,0 +1,10 @@
+from intervalsicu.api.intervals_object import IntervalsObject
+
+
+class PowerCurve(dict):
+    fields = ["activities", "list"]
+
+    def __init__(self, **kwargs):
+        IntervalsObject.validate(set(PowerCurve.fields), set(kwargs.keys()))
+
+        dict.__init__(self, **kwargs)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,7 @@
 import pytest
 from datetime import date
 
-from intervalsicu import Activity, Calendar, Event, Intervals, Folder, Wellness, Workout
+from intervalsicu import Activity, Calendar, Event, Intervals, Folder, Wellness, Workout, PowerCurve
 
 
 def to_kwargs(l):
@@ -39,6 +39,8 @@ class MockResponse(object):
             return Workout(**to_kwargs(Workout.fields))
         if 'calendar' in self.url:
             return [Calendar()]
+        if self.url.endswith('power-curves'):
+            return PowerCurve(**to_kwargs((PowerCurve.fields)))
 
 
 class MockSession(object):
@@ -124,3 +126,7 @@ def test_workouts(intervals_svc):
 
 def test_workout(intervals_svc):
     intervals_svc.workout(1)
+
+
+def test_power_curve(intervals_svc):
+    intervals_svc.power_curve()


### PR DESCRIPTION
This PR adds a function to get power curves using the endpoint `/api/v1/athlete/{athlete_id}/power-curves` and includes sensible defaults for the available parameters. 

I have attempted to match the implementation style of previous functions/docstrings/tests, but I am unsure if this is as expected. Please let me know if there are any changes required. 

This PR also bumps pytest so that testing can be run on Python 3.10 and 3.11. Please let me know if this should be split into a secondary PR. 